### PR TITLE
Fixed "head wave" typo

### DIFF
--- a/TwitchToolkit/Defs/StoreIncidents/StoreIncidents.xml
+++ b/TwitchToolkit/Defs/StoreIncidents/StoreIncidents.xml
@@ -114,7 +114,7 @@
 
   <TwitchToolkit.Incidents.StoreIncidentSimple>
     <defName>HeatWave</defName>
-    <label>head wave</label>
+    <label>heat wave</label>
     <abbreviation>heatwave</abbreviation>
     <cost>750</cost>
     <eventCap>2</eventCap>


### PR DESCRIPTION
The "heat wave" event label was previously a typo: "head wave" in StoreIncidents.xml 
Shows up when using "!buy heatwave" as "Event Head wave purchased by "